### PR TITLE
Fix double declaration

### DIFF
--- a/src/app_evdev.c
+++ b/src/app_evdev.c
@@ -93,7 +93,7 @@ void a__EvdevScan() {
 				if (!dev_empty) {
 					ATTO_PRINT("Exceeded max devices %d", ATTO_EVDEV_MAX_DEVICES);
 				} else {
-					char buffer[12 + ATTO_EVDEV_DEVICE_MAX_NAME] = "/dev/input/";
+					buffer[12 + ATTO_EVDEV_DEVICE_MAX_NAME] = "/dev/input/";
 					strcpy(buffer + 11, dent->d_name);
 					dev_empty->fd = open(buffer, O_RDONLY | O_NONBLOCK);
 					if (dev_empty->fd < 0) {


### PR DESCRIPTION
First shadowed variable declaration:
`53 	char buffer[8192];`
Second declaration:
`96    char buffer[12 + ATTO_EVDEV_DEVICE_MAX_NAME] = "/dev/input/";`