### PR TITLE
Windows fix warnings

### DIFF
--- a/src/app_windows.c
+++ b/src/app_windows.c
@@ -163,9 +163,10 @@ static void a__AppCleanup(void) {
 
 static void a__AppOpenConsole(void) {
 	AllocConsole();
-	freopen("CONIN$", "r", stdin);
-	freopen("CONOUT$", "w", stdout);
-	freopen("CONOUT$", "w", stderr);
+	FILE* dummy_file;
+	freopen_s(&dummy_file, "CONIN$", "r", stdin);
+	freopen_s(&dummy_file, "CONOUT$", "w", stdout);
+	freopen_s(&dummy_file, "CONOUT$", "w", stderr);
 }
 
 #if 0


### PR DESCRIPTION
На виндовой сборке вылетают варнинги:
```
../src/app_windows.c:166:2: warning: 'freopen' is deprecated: This function or variable may be unsafe. Consider using freopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [-Wdeprecated-declarations]
        freopen("CONIN$", "r", stdin);
```
И собственно этот пулреквест их решает.