### PR TITLE
app: add aAppRedraw() function to control redraw on x11

### DIFF
--- a/include/atto/app.h
+++ b/include/atto/app.h
@@ -135,10 +135,15 @@ struct AAppState {
 		unsigned int buttons;
 	} pointer;
 	int grabbed;
+	int redraw;
 };
 
 /* hide cursor, pin mouse to window center and report only delta */
 void aAppGrabInput(int grab);
+
+// App redraws indefinitely by default.
+// Call this with redraw=0 on each frame to stop auto-redraw on vsync.
+void aAppRedraw(int redraw);
 
 extern const struct AAppState *a_app_state;
 

--- a/src/app_x11.c
+++ b/src/app_x11.c
@@ -263,8 +263,9 @@ int main(int argc, char *argv[]) {
 	if (a__app_proctable.resize)
 		a__app_proctable.resize(timestamp, 0, 0);
 
+	a__app_state.redraw = 1;
 	for (;;) {
-		while (XPending(a__x11.display)) {
+		while (!a__app_state.redraw || XPending(a__x11.display)) {
 			XEvent e;
 			XNextEvent(a__x11.display, &e);
 			switch (e.type) {
@@ -281,6 +282,9 @@ int main(int argc, char *argv[]) {
 
 				if (a__app_proctable.resize)
 					a__app_proctable.resize(timestamp, oldw, oldh);
+
+				// Resize forces redraw
+				a__app_state.redraw = 1;
 			} break;
 
 			case ButtonPress:
@@ -301,6 +305,9 @@ int main(int argc, char *argv[]) {
 			if (!last_paint)
 				last_paint = now;
 			dt = (now - last_paint) * 1e-6f;
+
+			// Force redraw for the next frame
+			a__app_state.redraw = 1;
 
 			if (a__app_proctable.paint)
 				a__app_proctable.paint(now, dt);
@@ -337,4 +344,8 @@ void aAppGrabInput(int grab) {
 		XUngrabPointer(a__x11.display, CurrentTime);
 	}
 	a__app_state.grabbed = grab;
+}
+
+void aAppRedraw(int redraw) {
+	a__app_state.redraw = (redraw != 0);
 }


### PR DESCRIPTION
aAppRedraw(0) in paint() stops automatic repaint until aAppRedraw(1) is called again.

Resize automatically restarts automatic repainting.

Only implemented for x11 backend for now.